### PR TITLE
returned empty table from Save

### DIFF
--- a/main.nut
+++ b/main.nut
@@ -126,7 +126,7 @@ class IndustryConstructor extends GSController {
 
 // Save function
 function IndustryConstructor::Save() {
-    return null;
+    return {};
 }
 
 // Load function


### PR DESCRIPTION
Fixes the "script took too long to Save" error.